### PR TITLE
Use png canvas export to download final image

### DIFF
--- a/results.html
+++ b/results.html
@@ -51,7 +51,7 @@
 <p>Идеологическое сопоставление не завершено и гораздо менее точное, чем значения и оси.</p>
 <p>Вы можете отправить эти результаты, скопировав и вставив URL в верхней части страницы или используя изображение ниже.</p>
 <hr/>
-<canvas id="banner" width=800 height=650 style="font-family:Montserrat"></canvas>
+<img src="" id="banner">
 <button class="button" onclick="location.href='index.html';" style="background-color: #2196f3;">Назад</button> <br>
 <!-- Website visit statistics - no personal information is collected! -->
 <script src="https://www.w3counter.com/tracker.js?id=114877"></script>
@@ -141,8 +141,10 @@
     }
 
     window.onload = function() {
-        var c = document.getElementById("banner")
+        var c = document.createElement("canvas")
         var ctx = c.getContext("2d")
+        c.width = 800;
+        c.height = 650;
         ctx.fillStyle = "#EEEEEE"
         ctx.fillRect(0,0,800,650)
 
@@ -212,6 +214,8 @@
         ctx.fillText("Дипломатическая Ось: " + document.getElementById("diplomatic-label").innerHTML, 400, 295)
         ctx.fillText("Гражданская Ось: " + document.getElementById("state-label").innerHTML, 400, 415)
         ctx.fillText("Социальная Ось: " + document.getElementById("society-label").innerHTML, 400, 535)
+
+        document.getElementById("banner").src = c.toDataURL();
     }
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -182,7 +182,7 @@ div.tradition {
 span.weight-300 {
     font-weight: 300;
 }
-canvas {
+#banner {
     border-color: #444444;
     border-style: solid;
     border-width: 2px;


### PR DESCRIPTION
Currently there is no way to save the image with results in a mobile browser (tried Opera and Chrome on Android). On the English 8values the image can be saved by tapping it. This is the fix from upstream that enables this functionality.